### PR TITLE
feat(cmd): subscriptions and chroot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-onedrive-cli",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "@adobe/helix-onedrive-support": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-onedrive-support/-/helix-onedrive-support-1.3.0.tgz",
-      "integrity": "sha512-q4P+QdlegUk841lffXnx8DFrwByZOS5SWgzaKFXiF3MgboSDxWnhg6oAf/a3anlYxQacz8OJvELKtk61Mn/ikw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-onedrive-support/-/helix-onedrive-support-1.4.0.tgz",
+      "integrity": "sha512-D8cunGY8x71o+HY4YORla8UlMvOWY2bgLYdsuRcCVsbemf6pj2aM90GRxr/KdnguCP+Y0IqjPMLq475527k+hg==",
       "requires": {
         "adal-node": "0.2.1",
         "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/adobe/helix-onedrive-cli#readme",
   "dependencies": {
     "@adobe/helix-log": "4.5.0",
-    "@adobe/helix-onedrive-support": "1.3.0",
+    "@adobe/helix-onedrive-support": "^1.4.0",
     "chalk": "3.0.0",
     "cookie-parser": "1.4.4",
     "dotenv": "8.2.0",

--- a/src/onedrive.cmd.js
+++ b/src/onedrive.cmd.js
@@ -37,6 +37,11 @@ function install(yargs) {
       handler: onedrive.resolve,
     })
     .command({
+      command: 'chroot <root>',
+      desc: 'Manually set a root drive.',
+      handler: onedrive.chroot,
+    })
+    .command({
       command: 'ls [path]',
       desc: 'Lists the contents of the [path]',
       handler: onedrive.ls,
@@ -55,6 +60,11 @@ function install(yargs) {
       command: 'put <local> [path]]',
       desc: 'upload the local file.',
       handler: onedrive.upload,
+    })
+    .command({
+      command: 'subscriptions',
+      desc: 'list active subscriptions.',
+      handler: onedrive.subscriptions,
     });
 }
 

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -119,6 +119,22 @@ async function resolve(args) {
   info(chalk`\nroot path updated: {yellow ${canonicalPath}}`);
 }
 
+async function chroot(args) {
+  const [,, driveId] = args.root.split('/');
+
+  const od = getOneDriveClient();
+  const result = await od.getRootFolderId(driveId);
+  const { id, name, webUrl } = result;
+  const canonicalPath = `/drives/${driveId}/items/${id}`;
+  info(chalk`   Name: {yellow ${name}}`);
+  info(chalk`     Id: {yellow ${id}}`);
+  info(chalk`    URL: {yellow ${webUrl}}`);
+  state.root = canonicalPath;
+  state.cwd = '/';
+  await saveState();
+  info(chalk`\nroot path updated: {yellow ${state.root}}`);
+}
+
 async function getDriveItem(url) {
   // todo: parse better
   const [, , driveId, , id] = url.split('/');
@@ -260,12 +276,25 @@ async function upload(args) {
   await od.uploadDriveItem(buf, driveItem, dst);
 }
 
+async function subscriptions() {
+  const od = getOneDriveClient();
+  const result = await od.listSubscriptions();
+  result.value.forEach((item) => {
+    const { id, resource, expirationDateTime } = item;
+    info(chalk`       Id: {yellow ${id}}`);
+    info(chalk` Resource: {yellow ${resource}}`);
+    info(chalk`  Expires: {yellow ${expirationDateTime}}\n`);
+  });
+}
+
 module.exports = {
   me,
   resolve,
+  chroot,
   ls,
   download,
   upload,
   login,
   logout,
+  subscriptions,
 };


### PR DESCRIPTION
- `1d subscriptions` lists subscriptions, including its root drive
- `1d chroot <root>` lets one change to that drive, in order to use `1d ls [path]`