### PR TITLE
fix(onedrive): refreshToken from .auth.json is not taken into account

### DIFF
--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -67,7 +67,7 @@ function getOneDriveClient() {
   client = new OneDrive({
     clientId,
     clientSecret,
-    refreshToken,
+    refreshToken: refreshToken || tokens.refreshToken,
     tenant,
     accessToken,
     expiresOn,


### PR DESCRIPTION
If `process.env` contains no `AZURE_APP_REFRESH_TOKEN`, use the refreshToken from `.auth.json`

Note, that this was causing strange issues (`AccessDenied` or `BadRequest`) when the `.auth.json` file was updated on expiry and suddenly contained a different format, which was unsuitable for authentication.