### PR TITLE
feat(poll): add skip parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5956,9 +5956,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/src/onedrive.cmd.js
+++ b/src/onedrive.cmd.js
@@ -96,6 +96,12 @@ function install(yargs) {
       command: 'poll',
       desc: 'continuously polls for changes in a drive.',
       handler: onedrive.poll,
+      builder: (y) => y.option('skip', {
+        alias: 's',
+        type: 'boolean',
+        description: 'Skip initial building of path hierarchy',
+        default: false,
+      }),
     })
     .commandDir('excel');
 }

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -303,6 +303,8 @@ async function deleteSubscription(args) {
 }
 
 async function poll(args) {
+  const { skip } = args;
+
   const state = await loadState();
   if (!state.root) {
     throw Error(chalk`${args._[0]} needs path. use '{grey ${args.$0} resolve}' to set root.`);
@@ -311,16 +313,24 @@ async function poll(args) {
   const od = getOneDriveClient();
   const resource = `/drives/${state.root.split('/')[2]}/root`;
 
-  info('Fetching initial drive contents, this might take a while...');
-  const initial = await od.fetchChanges(resource);
-  const pathCache = initial.changes.filter(
-    (item) => item.id && item.file && item.name && item.parentReference,
-  ).reduce((map, item) => {
-    const [, parent] = item.parentReference.path.split(':');
-    map.set(item.id, `${parent}/${item.name}`);
-    return map;
-  }, new Map());
-  let nextToken = initial.token;
+  const pathCache = new Map();
+  let nextToken;
+
+  if (!skip) {
+    info('Fetching initial drive contents, this might take a while...');
+    const initial = await od.fetchChanges(resource);
+    initial.changes.filter(
+      (item) => item.id && item.file && item.name && item.parentReference,
+    ).reduce((map, item) => {
+      const [, parent] = item.parentReference.path.split(':');
+      map.set(item.id, `${parent}/${item.name}`);
+      return map;
+    }, pathCache);
+    nextToken = initial.token;
+  } else {
+    const initial = await od.fetchChanges(resource, 'latest');
+    nextToken = initial.token;
+  }
 
   info('Polling for changes, enter Ctrl-c to exit.');
   process.on('SIGINT', () => {
@@ -343,7 +353,7 @@ async function poll(args) {
         ? `${change.parentReference.path.split(':')[1]}/${change.name}` : null;
 
       if (change.deleted) {
-        info(chalk`{red - ${cachedPath}}`);
+        info(chalk`{red - ${cachedPath || 'unknown'}}`);
         pathCache.delete(change.id);
       } else if (!cachedPath) {
         info(chalk`{green + ${changePath}}`);


### PR DESCRIPTION
Skip building the initial set of items in a drive. Deletions of items not seen yet will be reported as `unknown`.

Also, bump up version of lodash to 4.17.19